### PR TITLE
Configure PyPI Trusted Publisher

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,6 +8,10 @@ jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distribution 📦 to PyPI
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: write
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -31,5 +35,3 @@ jobs:
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Changes publishing to PyPI removing the need for a token. Following these docs:
https://docs.pypi.org/trusted-publishers/using-a-publisher/

Set GitHub as Trusted Publisher in PyPI: https://pypi.org/manage/project/distributed-downloader/settings/publishing/

As we had done for [pybioclip](https://github.com/Imageomics/pybioclip/pull/120).